### PR TITLE
feat: Implement comprehensive deletion for messages and reactions

### DIFF
--- a/src/routes/messageRoutes.ts
+++ b/src/routes/messageRoutes.ts
@@ -14,7 +14,9 @@ import {
   initReaction,         
   uploadReactionVideo,
   getReactionsByMessageId,
-  getReactionById
+  getReactionById,
+  deleteReactionById,
+  deleteAllReactionsForMessage
 } from '../controllers/messageController';
 import { requireAuth } from '../middlewares/middleware';
 import multer from 'multer';
@@ -122,5 +124,7 @@ router.post('/reactions/:id/reply', recordTextReply);
 router.post('/reactions/:id/skip', skipReaction);
 router.delete('/messages/:id/delete', deleteMessageAndReaction);
 router.get('/reactions/:id', getReactionById);
+router.delete('/reactions/:reactionId/delete', requireAuth, deleteReactionById);
+router.delete('/messages/:messageId/reactions/delete', requireAuth, deleteAllReactionsForMessage);
 
 export default router;


### PR DESCRIPTION
Adds backend functionality to delete messages and reactions with associated Cloudinary assets.

Key changes:
- Updated `deleteMessageAndReaction` to remove media (message image, reaction videos) from Cloudinary after deleting database entries.
- Added `deleteReactionById` to delete a single reaction, its replies, and its video from Cloudinary.
- Added `deleteAllReactionsForMessage` to delete all reactions for a given message, including their replies and Cloudinary videos.
- Introduced a `deleteFromCloudinary` helper function to handle parsing Cloudinary URLs and deleting assets by public_id.

All new deletion routes are protected by authentication. Error handling is implemented to log Cloudinary errors without failing the primary database deletion operations. This provides the necessary backend support for enhanced message and reaction management.