### PR TITLE
Potential fix for code scanning alert no. 11: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "pg": "^8.15.6",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/src/routes/messageRoutes.ts
+++ b/src/routes/messageRoutes.ts
@@ -20,6 +20,7 @@ import {
   deleteAllReactionsForMessage
 } from '../controllers/messageController';
 import { requireAuth } from '../middlewares/middleware';
+import rateLimit from 'express-rate-limit';
 import multer from 'multer';
 import { v2 as cloudinary } from 'cloudinary';
 // Readable import removed as functions using it are moved
@@ -64,6 +65,12 @@ router.post('/reactions/:id/skip', skipReaction);
 router.delete('/messages/:id/delete', deleteMessageAndReaction);
 router.get('/reactions/:id', getReactionById);
 router.delete('/reactions/:reactionId/delete', requireAuth, deleteReactionById);
-router.delete('/messages/:messageId/reactions/delete', requireAuth, deleteAllReactionsForMessage);
+const deleteReactionsRateLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 10, // Limit each IP to 10 requests per windowMs
+  message: 'Too many requests, please try again later.',
+});
+
+router.delete('/messages/:messageId/reactions/delete', requireAuth, deleteReactionsRateLimiter, deleteAllReactionsForMessage);
 
 export default router;


### PR DESCRIPTION
Potential fix for [https://github.com/D3Brooksster/reactlyve-backend/security/code-scanning/11](https://github.com/D3Brooksster/reactlyve-backend/security/code-scanning/11)

To fix the issue, we will add rate limiting to the `/messages/:messageId/reactions/delete` route using the `express-rate-limit` package. This package allows us to define a rate limiter middleware that restricts the number of requests a client can make to the endpoint within a specified time window. 

Steps:
1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the file.
3. Define a rate limiter middleware with appropriate settings (e.g., a maximum of 10 requests per minute).
4. Apply the rate limiter middleware to the `/messages/:messageId/reactions/delete` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
