### PR TITLE
Potential fix for code scanning alert no. 16: Missing rate limiting

### DIFF
--- a/src/routes/messageRoutes.ts
+++ b/src/routes/messageRoutes.ts
@@ -64,7 +64,13 @@ router.post('/reactions/:id/reply', recordTextReply);
 router.post('/reactions/:id/skip', skipReaction);
 router.delete('/messages/:id/delete', deleteMessageAndReaction);
 router.get('/reactions/:id', getReactionById);
-router.delete('/reactions/:reactionId/delete', requireAuth, deleteReactionById);
+const deleteReactionRateLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 10, // Limit each IP to 10 requests per windowMs
+  message: 'Too many requests, please try again later.',
+});
+
+router.delete('/reactions/:reactionId/delete', requireAuth, deleteReactionRateLimiter, deleteReactionById);
 const deleteReactionsRateLimiter = rateLimit({
   windowMs: 1 * 60 * 1000, // 1 minute
   max: 10, // Limit each IP to 10 requests per windowMs


### PR DESCRIPTION
Potential fix for [https://github.com/D3Brooksster/reactlyve-backend/security/code-scanning/16](https://github.com/D3Brooksster/reactlyve-backend/security/code-scanning/16)

To fix the issue, we will add a rate-limiting middleware to the `DELETE /reactions/:reactionId/delete` route. This middleware will limit the number of requests that can be made to the route within a specified time window. We will use the `express-rate-limit` package, which is already imported in the file, to implement this functionality.

The rate limiter will be configured to allow a maximum of 10 requests per minute per IP address. This is consistent with the rate limiter already defined for another route (`DELETE /messages/:messageId/reactions/delete`) in the same file. The rate limiter will return a "Too many requests, please try again later." message if the limit is exceeded.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
