### PR TITLE
Potential fix for code scanning alert no. 7: Missing rate limiting

### DIFF
--- a/src/routes/messageRoutes.ts
+++ b/src/routes/messageRoutes.ts
@@ -50,7 +50,13 @@ const upload = multer({
 // Cloudinary utility functions uploadVideoToCloudinary and uploadToCloudinarymedia moved to utils/cloudinaryUtils.ts
 
 // === Routes ===
-router.post('/messages/send', requireAuth, sendMessage);
+const sendMessageRateLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 10, // Limit each IP to 10 requests per windowMs
+  message: 'Too many requests, please try again later.',
+});
+
+router.post('/messages/send', requireAuth, sendMessageRateLimiter, sendMessage);
 router.get('/messages', requireAuth, getAllMessages);
 router.get('/messages/:id', getMessageById);
 router.put('/messages/:id', requireAuth, updateMessage); // Added PUT route for updating messages


### PR DESCRIPTION
Potential fix for [https://github.com/D3Brooksster/reactlyve-backend/security/code-scanning/7](https://github.com/D3Brooksster/reactlyve-backend/security/code-scanning/7)

To fix the issue, we will add a rate-limiting middleware to the `/messages/send` route. This will ensure that the number of requests to this endpoint is capped within a specified time window, preventing abuse and mitigating the risk of denial-of-service attacks.

1. We will use the `express-rate-limit` package, which is already imported in the file, to define a rate limiter specifically for the `/messages/send` route.
2. The rate limiter will allow a maximum of 10 requests per minute from a single IP address. This limit can be adjusted based on the application's expected traffic and performance requirements.
3. The rate limiter will be applied as middleware to the `/messages/send` route, alongside the existing `requireAuth` middleware.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
