### PR TITLE
Fix: Prevent attempts to delete non-Cloudinary URLs

### DIFF
--- a/src/utils/cloudinaryUtils.ts
+++ b/src/utils/cloudinaryUtils.ts
@@ -12,6 +12,15 @@ cloudinary.config({
 });
 
 export const extractPublicIdAndResourceType = (cloudinaryUrl: string): { public_id: string; resource_type: 'image' | 'video' | 'raw' } | null => {
+  if (typeof cloudinaryUrl !== 'string' || !cloudinaryUrl.includes('cloudinary.com')) {
+    if (typeof cloudinaryUrl !== 'string') {
+      console.warn(`Invalid URL format for public ID extraction: Expected a string, but received ${typeof cloudinaryUrl}.`);
+    } else {
+      console.log(`Attempted to extract public ID from non-Cloudinary URL: ${cloudinaryUrl}`);
+    }
+    return null;
+  }
+
   try {
     const url = new URL(cloudinaryUrl);
     const pathname = url.pathname;
@@ -70,6 +79,18 @@ export const extractPublicIdAndResourceType = (cloudinaryUrl: string): { public_
 
 export const deleteFromCloudinary = (cloudinaryUrl: string): Promise<any> => {
   return new Promise((resolve, reject) => {
+    try {
+      const url = new URL(cloudinaryUrl);
+      if (!url.hostname.includes('cloudinary.com')) {
+        console.log(`Skipping deletion for non-Cloudinary URL: ${cloudinaryUrl}`);
+        return resolve({ message: "Skipped non-Cloudinary URL" });
+      }
+    } catch (error) {
+      // If URL parsing fails, it's definitely not a valid Cloudinary URL for our purposes
+      console.warn(`Invalid URL provided to deleteFromCloudinary: ${cloudinaryUrl}`, error);
+      return resolve({ message: "Skipped invalid URL" });
+    }
+
     const extracted = extractPublicIdAndResourceType(cloudinaryUrl);
     if (!extracted) {
       return reject(new Error(`Failed to extract public_id or resource_type from URL: ${cloudinaryUrl}`));


### PR DESCRIPTION
The `deleteFromCloudinary` utility was attempting to process any URL passed to it, leading to errors when encountering non-Cloudinary URLs such as Google User Content links during account cleanup.

This commit introduces the following changes:
- `deleteFromCloudinary` now first checks if the URL is a valid Cloudinary URL (hostname includes 'cloudinary.com'). If not, it logs a message and resolves, skipping any deletion attempt. It also handles malformed URLs gracefully.
- `extractPublicIdAndResourceType` has also been made more robust by adding similar initial checks for URL validity and whether it's a Cloudinary domain, returning null early if not.

These changes ensure that only actual Cloudinary URLs are processed for deletion, resolving the errors previously logged during the account cleanup job when encountering user profile pictures hosted on other services. The `accountCleanupJob.ts` did not require modification as its existing error handling will now primarily catch actual Cloudinary API issues.