### PR TITLE
Potential fix for code scanning alert no. 20: Incomplete URL substring sanitization

### DIFF
--- a/src/utils/cloudinaryUtils.ts
+++ b/src/utils/cloudinaryUtils.ts
@@ -12,12 +12,19 @@ cloudinary.config({
 });
 
 export const extractPublicIdAndResourceType = (cloudinaryUrl: string): { public_id: string; resource_type: 'image' | 'video' | 'raw' } | null => {
-  if (typeof cloudinaryUrl !== 'string' || !cloudinaryUrl.includes('cloudinary.com')) {
-    if (typeof cloudinaryUrl !== 'string') {
-      console.warn(`Invalid URL format for public ID extraction: Expected a string, but received ${typeof cloudinaryUrl}.`);
-    } else {
-      console.log(`Attempted to extract public ID from non-Cloudinary URL: ${cloudinaryUrl}`);
+  const allowedHosts = ['res.cloudinary.com'];
+  try {
+    const url = new URL(cloudinaryUrl);
+    if (typeof cloudinaryUrl !== 'string' || !allowedHosts.includes(url.host)) {
+      if (typeof cloudinaryUrl !== 'string') {
+        console.warn(`Invalid URL format for public ID extraction: Expected a string, but received ${typeof cloudinaryUrl}.`);
+      } else {
+        console.log(`Attempted to extract public ID from non-Cloudinary URL: ${cloudinaryUrl}`);
+      }
+      return null;
     }
+  } catch (error) {
+    console.error(`Failed to parse URL for host validation: ${cloudinaryUrl}`, { error });
     return null;
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/D3Brooksster/reactlyve-backend/security/code-scanning/20](https://github.com/D3Brooksster/reactlyve-backend/security/code-scanning/20)

To fix the issue, we need to replace the substring check (`cloudinaryUrl.includes('cloudinary.com')`) with a more robust validation that ensures the host of the URL matches a trusted domain. This can be achieved by parsing the URL using the `URL` class and comparing its `host` property against a whitelist of allowed hosts. This approach ensures that only URLs with the exact trusted domain or its subdomains are accepted.

Steps to implement the fix:
1. Parse the `cloudinaryUrl` using the `URL` class.
2. Extract the `host` property from the parsed URL.
3. Compare the `host` against a predefined whitelist of allowed hosts (e.g., `['res.cloudinary.com']`).
4. If the `host` is not in the whitelist, log a warning and return `null`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
