### PR TITLE
Make Cloudinary overlay ID configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ GOOGLE_CALLBACK_URL=http://localhost:3000/api/auth/google/callback # Adjust if y
 CLOUDINARY_CLOUD_NAME=your_cloudinary_cloud_name
 CLOUDINARY_API_KEY=your_cloudinary_api_key
 CLOUDINARY_API_SECRET=your_cloudinary_api_secret
+CLOUDINARY_OVERLAY_PUBLIC_ID=Reactlyve_Logo_bi78md
 
 # Notification URL for Cloudinary to POST moderation results
 # This value is included with each upload and manual review request so
@@ -234,7 +235,9 @@ directly from the AWS Rekognition tab in the Cloudinary console.
 If a webhook is configured in Cloudinary, the final decision will be posted back
 to the backend. When a moderation decision is returned with status `approved`,
 the webhook handler calls Cloudinary's `explicit` API to generate the overlay
-and thumbnail derivatives so they appear alongside the original asset.
+and thumbnail derivatives so they appear alongside the original asset. The
+overlay image used can be customized via the `CLOUDINARY_OVERLAY_PUBLIC_ID`
+environment variable.
 To avoid race conditions where Cloudinary reports the asset too soon,
 the server now retries the `explicit` request several times with a short
 delay. Rejected assets will not have derivatives until they are manually

--- a/src/utils/cloudinaryUtils.d.ts
+++ b/src/utils/cloudinaryUtils.d.ts
@@ -27,3 +27,4 @@ export declare const NEW_WORKING_OVERLAY_PARAMS: string;
 export declare const SMALL_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING: string;
 export declare const LARGE_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING: string;
 export declare const IMAGE_OVERLAY_TRANSFORMATION_STRING: string;
+export declare const OVERLAY_PUBLIC_ID: string;

--- a/src/utils/cloudinaryUtils.js
+++ b/src/utils/cloudinaryUtils.js
@@ -3,18 +3,20 @@ const dotenv = require('dotenv');
 const { URL } = require('url');
 const { Readable } = require('stream');
 
-const NEW_WORKING_OVERLAY_PARAMS = "l_Reactlyve_Logo_bi78md/fl_layer_apply,w_0.3,g_south_east,x_10,y_10";
-const SMALL_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING = "f_auto,q_auto/" + NEW_WORKING_OVERLAY_PARAMS;
-const LARGE_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING = "w_1280,c_limit,q_auto,f_auto/" + NEW_WORKING_OVERLAY_PARAMS;
-const IMAGE_OVERLAY_TRANSFORMATION_STRING = "f_auto,q_auto/" + NEW_WORKING_OVERLAY_PARAMS;
-const JUST_THE_OVERLAY_TRANSFORMATION = "l_reactlyve:81ad2da14e6d70f29418ba02a7d2aa96,w_0.1,g_south_east,x_10,y_10,fl_layer_apply"; // This might be unused or deprecated after this change
+dotenv.config();
+
+const OVERLAY_PUBLIC_ID = process.env.CLOUDINARY_OVERLAY_PUBLIC_ID || 'Reactlyve_Logo_bi78md';
+const NEW_WORKING_OVERLAY_PARAMS = `l_${OVERLAY_PUBLIC_ID}/fl_layer_apply,w_0.3,g_south_east,x_10,y_10`;
+const SMALL_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING = `f_auto,q_auto/${NEW_WORKING_OVERLAY_PARAMS}`;
+const LARGE_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING = `w_1280,c_limit,q_auto,f_auto/${NEW_WORKING_OVERLAY_PARAMS}`;
+const IMAGE_OVERLAY_TRANSFORMATION_STRING = `f_auto,q_auto/${NEW_WORKING_OVERLAY_PARAMS}`;
+const JUST_THE_OVERLAY_TRANSFORMATION = `l_${OVERLAY_PUBLIC_ID},w_0.1,g_south_east,x_10,y_10,fl_layer_apply`; // This might be unused or deprecated after this change
 
 exports.NEW_WORKING_OVERLAY_PARAMS = NEW_WORKING_OVERLAY_PARAMS;
 exports.SMALL_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING = SMALL_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING;
 exports.LARGE_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING = LARGE_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING;
 exports.IMAGE_OVERLAY_TRANSFORMATION_STRING = IMAGE_OVERLAY_TRANSFORMATION_STRING;
-
-dotenv.config();
+exports.OVERLAY_PUBLIC_ID = OVERLAY_PUBLIC_ID;
 
 cloudinary.config({
   cloud_name: process.env.CLOUDINARY_CLOUD_NAME,


### PR DESCRIPTION
## Summary
- read overlay ID from `CLOUDINARY_OVERLAY_PUBLIC_ID`
- document `CLOUDINARY_OVERLAY_PUBLIC_ID` environment variable
- note overlay variable in docs

## Testing
- `npm test --silent` *(fails: RecordReactionLog errors etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684ce51e12cc8324ac153c5bc9387101