### PR TITLE
Update overlay logo width settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ CLOUDINARY_CLOUD_NAME=your_cloudinary_cloud_name
 CLOUDINARY_API_KEY=your_cloudinary_api_key
 CLOUDINARY_API_SECRET=your_cloudinary_api_secret
 CLOUDINARY_OVERLAY_PUBLIC_ID=Reactlyve_Logo_bi78md
-CLOUDINARY_OVERLAY_WIDTH_PERCENT=0.2
+CLOUDINARY_OVERLAY_WIDTH_PERCENT=0.3
 
 # Notification URL for Cloudinary to POST moderation results
 # This value is included with each upload and manual review request so
@@ -240,7 +240,7 @@ and thumbnail derivatives so they appear alongside the original asset. The
 overlay image used can be customized via the `CLOUDINARY_OVERLAY_PUBLIC_ID`
 environment variable. The width of the overlay is relative to the underlying
 asset and can be adjusted via `CLOUDINARY_OVERLAY_WIDTH_PERCENT` (defaults to
-`0.2`).
+`0.3`).
 To avoid race conditions where Cloudinary reports the asset too soon,
 the server now retries the `explicit` request several times with a short
 delay. Rejected assets will not have derivatives until they are manually

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ CLOUDINARY_CLOUD_NAME=your_cloudinary_cloud_name
 CLOUDINARY_API_KEY=your_cloudinary_api_key
 CLOUDINARY_API_SECRET=your_cloudinary_api_secret
 CLOUDINARY_OVERLAY_PUBLIC_ID=Reactlyve_Logo_bi78md
-CLOUDINARY_OVERLAY_WIDTH_PERCENT=0.1
+CLOUDINARY_OVERLAY_WIDTH_PERCENT=0.3
 
 # Notification URL for Cloudinary to POST moderation results
 # This value is included with each upload and manual review request so
@@ -240,7 +240,7 @@ and thumbnail derivatives so they appear alongside the original asset. The
 overlay image used can be customized via the `CLOUDINARY_OVERLAY_PUBLIC_ID`
 environment variable. The width of the overlay is relative to the underlying
 asset and can be adjusted via `CLOUDINARY_OVERLAY_WIDTH_PERCENT` (defaults to
-`0.1`).
+`0.3`).
 To avoid race conditions where Cloudinary reports the asset too soon,
 the server now retries the `explicit` request several times with a short
 delay. Rejected assets will not have derivatives until they are manually

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ CLOUDINARY_CLOUD_NAME=your_cloudinary_cloud_name
 CLOUDINARY_API_KEY=your_cloudinary_api_key
 CLOUDINARY_API_SECRET=your_cloudinary_api_secret
 CLOUDINARY_OVERLAY_PUBLIC_ID=Reactlyve_Logo_bi78md
-CLOUDINARY_OVERLAY_WIDTH_PERCENT=0.3
+CLOUDINARY_OVERLAY_WIDTH_PERCENT=0.1
 
 # Notification URL for Cloudinary to POST moderation results
 # This value is included with each upload and manual review request so
@@ -240,7 +240,7 @@ and thumbnail derivatives so they appear alongside the original asset. The
 overlay image used can be customized via the `CLOUDINARY_OVERLAY_PUBLIC_ID`
 environment variable. The width of the overlay is relative to the underlying
 asset and can be adjusted via `CLOUDINARY_OVERLAY_WIDTH_PERCENT` (defaults to
-`0.3`).
+`0.1`).
 To avoid race conditions where Cloudinary reports the asset too soon,
 the server now retries the `explicit` request several times with a short
 delay. Rejected assets will not have derivatives until they are manually

--- a/README.md
+++ b/README.md
@@ -238,8 +238,9 @@ to the backend. When a moderation decision is returned with status `approved`,
 the webhook handler calls Cloudinary's `explicit` API to generate the overlay
 and thumbnail derivatives so they appear alongside the original asset. The
 overlay image used can be customized via the `CLOUDINARY_OVERLAY_PUBLIC_ID`
-environment variable, and its width as a percentage of the asset can be set with
-`CLOUDINARY_OVERLAY_WIDTH_PERCENT` (defaults to `0.15`).
+environment variable. The width of the overlay is relative to the underlying
+asset and can be adjusted via `CLOUDINARY_OVERLAY_WIDTH_PERCENT` (defaults to
+`0.15`).
 To avoid race conditions where Cloudinary reports the asset too soon,
 the server now retries the `explicit` request several times with a short
 delay. Rejected assets will not have derivatives until they are manually

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ CLOUDINARY_CLOUD_NAME=your_cloudinary_cloud_name
 CLOUDINARY_API_KEY=your_cloudinary_api_key
 CLOUDINARY_API_SECRET=your_cloudinary_api_secret
 CLOUDINARY_OVERLAY_PUBLIC_ID=Reactlyve_Logo_bi78md
-CLOUDINARY_OVERLAY_WIDTH_PERCENT=0.15
+CLOUDINARY_OVERLAY_WIDTH_PERCENT=0.2
 
 # Notification URL for Cloudinary to POST moderation results
 # This value is included with each upload and manual review request so
@@ -240,7 +240,7 @@ and thumbnail derivatives so they appear alongside the original asset. The
 overlay image used can be customized via the `CLOUDINARY_OVERLAY_PUBLIC_ID`
 environment variable. The width of the overlay is relative to the underlying
 asset and can be adjusted via `CLOUDINARY_OVERLAY_WIDTH_PERCENT` (defaults to
-`0.15`).
+`0.2`).
 To avoid race conditions where Cloudinary reports the asset too soon,
 the server now retries the `explicit` request several times with a short
 delay. Rejected assets will not have derivatives until they are manually

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ CLOUDINARY_CLOUD_NAME=your_cloudinary_cloud_name
 CLOUDINARY_API_KEY=your_cloudinary_api_key
 CLOUDINARY_API_SECRET=your_cloudinary_api_secret
 CLOUDINARY_OVERLAY_PUBLIC_ID=Reactlyve_Logo_bi78md
+CLOUDINARY_OVERLAY_WIDTH_PERCENT=0.15
 
 # Notification URL for Cloudinary to POST moderation results
 # This value is included with each upload and manual review request so
@@ -237,7 +238,8 @@ to the backend. When a moderation decision is returned with status `approved`,
 the webhook handler calls Cloudinary's `explicit` API to generate the overlay
 and thumbnail derivatives so they appear alongside the original asset. The
 overlay image used can be customized via the `CLOUDINARY_OVERLAY_PUBLIC_ID`
-environment variable.
+environment variable, and its width as a percentage of the asset can be set with
+`CLOUDINARY_OVERLAY_WIDTH_PERCENT` (defaults to `0.15`).
 To avoid race conditions where Cloudinary reports the asset too soon,
 the server now retries the `explicit` request several times with a short
 delay. Rejected assets will not have derivatives until they are manually

--- a/src/utils/cloudinaryUtils.d.ts
+++ b/src/utils/cloudinaryUtils.d.ts
@@ -30,6 +30,6 @@ export declare const IMAGE_OVERLAY_TRANSFORMATION_STRING: string;
 export declare const OVERLAY_PUBLIC_ID: string;
 /**
  * Overlay width as a fraction of the base asset's width. Derived from the
- * `CLOUDINARY_OVERLAY_WIDTH_PERCENT` environment variable. Defaults to `0.2`.
+ * `CLOUDINARY_OVERLAY_WIDTH_PERCENT` environment variable. Defaults to `0.3`.
  */
 export declare const OVERLAY_WIDTH_PERCENT: string;

--- a/src/utils/cloudinaryUtils.d.ts
+++ b/src/utils/cloudinaryUtils.d.ts
@@ -30,6 +30,6 @@ export declare const IMAGE_OVERLAY_TRANSFORMATION_STRING: string;
 export declare const OVERLAY_PUBLIC_ID: string;
 /**
  * Overlay width as a fraction of the base asset's width. Derived from the
- * `CLOUDINARY_OVERLAY_WIDTH_PERCENT` environment variable. Defaults to `0.3`.
+ * `CLOUDINARY_OVERLAY_WIDTH_PERCENT` environment variable. Defaults to `0.1`.
  */
 export declare const OVERLAY_WIDTH_PERCENT: string;

--- a/src/utils/cloudinaryUtils.d.ts
+++ b/src/utils/cloudinaryUtils.d.ts
@@ -28,4 +28,8 @@ export declare const SMALL_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING: string;
 export declare const LARGE_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING: string;
 export declare const IMAGE_OVERLAY_TRANSFORMATION_STRING: string;
 export declare const OVERLAY_PUBLIC_ID: string;
+/**
+ * Overlay width as a fraction of the base asset's width. Derived from the
+ * `CLOUDINARY_OVERLAY_WIDTH_PERCENT` environment variable. Defaults to `0.2`.
+ */
 export declare const OVERLAY_WIDTH_PERCENT: string;

--- a/src/utils/cloudinaryUtils.d.ts
+++ b/src/utils/cloudinaryUtils.d.ts
@@ -28,3 +28,4 @@ export declare const SMALL_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING: string;
 export declare const LARGE_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING: string;
 export declare const IMAGE_OVERLAY_TRANSFORMATION_STRING: string;
 export declare const OVERLAY_PUBLIC_ID: string;
+export declare const OVERLAY_WIDTH_PERCENT: string;

--- a/src/utils/cloudinaryUtils.d.ts
+++ b/src/utils/cloudinaryUtils.d.ts
@@ -30,6 +30,6 @@ export declare const IMAGE_OVERLAY_TRANSFORMATION_STRING: string;
 export declare const OVERLAY_PUBLIC_ID: string;
 /**
  * Overlay width as a fraction of the base asset's width. Derived from the
- * `CLOUDINARY_OVERLAY_WIDTH_PERCENT` environment variable. Defaults to `0.1`.
+ * `CLOUDINARY_OVERLAY_WIDTH_PERCENT` environment variable. Defaults to `0.3`.
  */
 export declare const OVERLAY_WIDTH_PERCENT: string;

--- a/src/utils/cloudinaryUtils.js
+++ b/src/utils/cloudinaryUtils.js
@@ -7,9 +7,9 @@ dotenv.config();
 
 const OVERLAY_PUBLIC_ID = process.env.CLOUDINARY_OVERLAY_PUBLIC_ID || 'Reactlyve_Logo_bi78md';
 
-// Allow overlay width to be specified as a percentage (e.g., "20" or "0.2")
-// Defaults to 0.2 (20%) if unset or invalid
-let OVERLAY_WIDTH_PERCENT = '0.2';
+// Allow overlay width to be specified as a percentage (e.g., "30" or "0.3")
+// Defaults to 0.3 (30%) if unset or invalid
+let OVERLAY_WIDTH_PERCENT = '0.3';
 if (process.env.CLOUDINARY_OVERLAY_WIDTH_PERCENT) {
   const rawValue = process.env.CLOUDINARY_OVERLAY_WIDTH_PERCENT;
   const parsed = parseFloat(rawValue);

--- a/src/utils/cloudinaryUtils.js
+++ b/src/utils/cloudinaryUtils.js
@@ -7,11 +7,11 @@ dotenv.config();
 
 const OVERLAY_PUBLIC_ID = process.env.CLOUDINARY_OVERLAY_PUBLIC_ID || 'Reactlyve_Logo_bi78md';
 const OVERLAY_WIDTH_PERCENT = process.env.CLOUDINARY_OVERLAY_WIDTH_PERCENT || '0.15';
-const NEW_WORKING_OVERLAY_PARAMS = `l_${OVERLAY_PUBLIC_ID}/fl_layer_apply,w_${OVERLAY_WIDTH_PERCENT},g_south_east,x_10,y_10`;
+const NEW_WORKING_OVERLAY_PARAMS = `l_${OVERLAY_PUBLIC_ID},fl_relative,w_${OVERLAY_WIDTH_PERCENT}/fl_layer_apply,g_south_east,x_10,y_10`;
 const SMALL_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING = `f_auto,q_auto/${NEW_WORKING_OVERLAY_PARAMS}`;
 const LARGE_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING = `w_1280,c_limit,q_auto,f_auto/${NEW_WORKING_OVERLAY_PARAMS}`;
 const IMAGE_OVERLAY_TRANSFORMATION_STRING = `f_auto,q_auto/${NEW_WORKING_OVERLAY_PARAMS}`;
-const JUST_THE_OVERLAY_TRANSFORMATION = `l_${OVERLAY_PUBLIC_ID},w_${OVERLAY_WIDTH_PERCENT},g_south_east,x_10,y_10,fl_layer_apply`; // This might be unused or deprecated after this change
+const JUST_THE_OVERLAY_TRANSFORMATION = `l_${OVERLAY_PUBLIC_ID},fl_relative,w_${OVERLAY_WIDTH_PERCENT},g_south_east,x_10,y_10,fl_layer_apply`; // This might be unused or deprecated after this change
 
 exports.NEW_WORKING_OVERLAY_PARAMS = NEW_WORKING_OVERLAY_PARAMS;
 exports.SMALL_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING = SMALL_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING;

--- a/src/utils/cloudinaryUtils.js
+++ b/src/utils/cloudinaryUtils.js
@@ -6,7 +6,17 @@ const { Readable } = require('stream');
 dotenv.config();
 
 const OVERLAY_PUBLIC_ID = process.env.CLOUDINARY_OVERLAY_PUBLIC_ID || 'Reactlyve_Logo_bi78md';
-const OVERLAY_WIDTH_PERCENT = process.env.CLOUDINARY_OVERLAY_WIDTH_PERCENT || '0.15';
+
+// Allow overlay width to be specified as a percentage (e.g., "20" or "0.2")
+// Defaults to 0.2 (20%) if unset or invalid
+let OVERLAY_WIDTH_PERCENT = '0.2';
+if (process.env.CLOUDINARY_OVERLAY_WIDTH_PERCENT) {
+  const rawValue = process.env.CLOUDINARY_OVERLAY_WIDTH_PERCENT;
+  const parsed = parseFloat(rawValue);
+  if (!isNaN(parsed) && parsed > 0) {
+    OVERLAY_WIDTH_PERCENT = parsed > 1 ? (parsed / 100).toString() : parsed.toString();
+  }
+}
 const NEW_WORKING_OVERLAY_PARAMS = `l_${OVERLAY_PUBLIC_ID},fl_relative,w_${OVERLAY_WIDTH_PERCENT}/fl_layer_apply,g_south_east,x_10,y_10`;
 const SMALL_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING = `f_auto,q_auto/${NEW_WORKING_OVERLAY_PARAMS}`;
 const LARGE_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING = `w_1280,c_limit,q_auto,f_auto/${NEW_WORKING_OVERLAY_PARAMS}`;

--- a/src/utils/cloudinaryUtils.js
+++ b/src/utils/cloudinaryUtils.js
@@ -8,8 +8,8 @@ dotenv.config();
 const OVERLAY_PUBLIC_ID = process.env.CLOUDINARY_OVERLAY_PUBLIC_ID || 'Reactlyve_Logo_bi78md';
 
 // Allow overlay width to be specified as a percentage (e.g., "30" or "0.3")
-// Defaults to 0.3 (30%) if unset or invalid
-let OVERLAY_WIDTH_PERCENT = '0.3';
+// Defaults to 0.1 (10%) if unset or invalid
+let OVERLAY_WIDTH_PERCENT = '0.1';
 if (process.env.CLOUDINARY_OVERLAY_WIDTH_PERCENT) {
   const rawValue = process.env.CLOUDINARY_OVERLAY_WIDTH_PERCENT;
   const parsed = parseFloat(rawValue);
@@ -28,6 +28,7 @@ exports.SMALL_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING = SMALL_FILE_VIDEO_OVERLA
 exports.LARGE_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING = LARGE_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING;
 exports.IMAGE_OVERLAY_TRANSFORMATION_STRING = IMAGE_OVERLAY_TRANSFORMATION_STRING;
 exports.OVERLAY_PUBLIC_ID = OVERLAY_PUBLIC_ID;
+exports.OVERLAY_WIDTH_PERCENT = OVERLAY_WIDTH_PERCENT;
 
 cloudinary.config({
   cloud_name: process.env.CLOUDINARY_CLOUD_NAME,

--- a/src/utils/cloudinaryUtils.js
+++ b/src/utils/cloudinaryUtils.js
@@ -6,11 +6,12 @@ const { Readable } = require('stream');
 dotenv.config();
 
 const OVERLAY_PUBLIC_ID = process.env.CLOUDINARY_OVERLAY_PUBLIC_ID || 'Reactlyve_Logo_bi78md';
-const NEW_WORKING_OVERLAY_PARAMS = `l_${OVERLAY_PUBLIC_ID}/fl_layer_apply,w_0.3,g_south_east,x_10,y_10`;
+const OVERLAY_WIDTH_PERCENT = process.env.CLOUDINARY_OVERLAY_WIDTH_PERCENT || '0.15';
+const NEW_WORKING_OVERLAY_PARAMS = `l_${OVERLAY_PUBLIC_ID}/fl_layer_apply,w_${OVERLAY_WIDTH_PERCENT},g_south_east,x_10,y_10`;
 const SMALL_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING = `f_auto,q_auto/${NEW_WORKING_OVERLAY_PARAMS}`;
 const LARGE_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING = `w_1280,c_limit,q_auto,f_auto/${NEW_WORKING_OVERLAY_PARAMS}`;
 const IMAGE_OVERLAY_TRANSFORMATION_STRING = `f_auto,q_auto/${NEW_WORKING_OVERLAY_PARAMS}`;
-const JUST_THE_OVERLAY_TRANSFORMATION = `l_${OVERLAY_PUBLIC_ID},w_0.1,g_south_east,x_10,y_10,fl_layer_apply`; // This might be unused or deprecated after this change
+const JUST_THE_OVERLAY_TRANSFORMATION = `l_${OVERLAY_PUBLIC_ID},w_${OVERLAY_WIDTH_PERCENT},g_south_east,x_10,y_10,fl_layer_apply`; // This might be unused or deprecated after this change
 
 exports.NEW_WORKING_OVERLAY_PARAMS = NEW_WORKING_OVERLAY_PARAMS;
 exports.SMALL_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING = SMALL_FILE_VIDEO_OVERLAY_TRANSFORMATION_STRING;

--- a/src/utils/cloudinaryUtils.js
+++ b/src/utils/cloudinaryUtils.js
@@ -8,8 +8,8 @@ dotenv.config();
 const OVERLAY_PUBLIC_ID = process.env.CLOUDINARY_OVERLAY_PUBLIC_ID || 'Reactlyve_Logo_bi78md';
 
 // Allow overlay width to be specified as a percentage (e.g., "30" or "0.3")
-// Defaults to 0.1 (10%) if unset or invalid
-let OVERLAY_WIDTH_PERCENT = '0.1';
+// Defaults to 0.3 (30%) if unset or invalid
+let OVERLAY_WIDTH_PERCENT = '0.3';
 if (process.env.CLOUDINARY_OVERLAY_WIDTH_PERCENT) {
   const rawValue = process.env.CLOUDINARY_OVERLAY_WIDTH_PERCENT;
   const parsed = parseFloat(rawValue);


### PR DESCRIPTION
## Summary
- make Cloudinary overlay logo width configurable via `CLOUDINARY_OVERLAY_WIDTH_PERCENT`
- document new environment variable

## Testing
- `npm install --include=dev`
- `npm test` *(fails: jest tests not passing)*

------
https://chatgpt.com/codex/tasks/task_e_684cfeb871188324899c4843f4c67a11