### PR TITLE
Add one-time shareable links for messages

### DIFF
--- a/migrations/202406141200_message_links.sql
+++ b/migrations/202406141200_message_links.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS message_links (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    message_id UUID REFERENCES messages(id) ON DELETE CASCADE,
+    link_id VARCHAR(32) UNIQUE NOT NULL,
+    passcode TEXT,
+    onetime BOOLEAN DEFAULT FALSE,
+    viewed BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_message_links_message_id ON message_links(message_id);

--- a/src/controllers/messageController.ts
+++ b/src/controllers/messageController.ts
@@ -851,6 +851,7 @@ export const getMessageByShareableLink = async (req: Request, res: Response): Pr
       message = legacy.rows[0];
     }
 
+    const linkViewed = message.viewed || false;
     const hasPasscode = !!message.passcode;
 
     if (hasPasscode) {
@@ -858,6 +859,7 @@ export const getMessageByShareableLink = async (req: Request, res: Response): Pr
         id: message.id,
         hasPasscode: true,
         onetime: message.onetime || false,
+        linkViewed,
         reaction_length: message.reaction_length,
         createdAt: new Date(message.createdat).toISOString()
       });
@@ -870,6 +872,7 @@ export const getMessageByShareableLink = async (req: Request, res: Response): Pr
       imageUrl: message.imageurl,
       hasPasscode: false,
       onetime: message.onetime || false,
+      linkViewed,
       reaction_length: message.reaction_length,
       mediaSize: message.media_size,
       createdAt: new Date(message.createdat).toISOString()
@@ -907,6 +910,8 @@ export const verifyMessagePasscode = async (req: Request, res: Response): Promis
       message = legacy.rows[0];
     }
 
+    const linkViewed = message.viewed || false;
+
     if (message.passcode !== passcode) {
       res.status(403).json({ error: 'Invalid passcode', verified: false });
       return;
@@ -925,6 +930,7 @@ export const verifyMessagePasscode = async (req: Request, res: Response): Promis
         imageUrl: message.imageurl,
         hasPasscode: true,
         onetime: message.onetime || false,
+        linkViewed,
         passcodeVerified: true,
         mediaSize: message.media_size,
         createdAt: new Date(message.createdat).toISOString()

--- a/src/controllers/messageController.ts
+++ b/src/controllers/messageController.ts
@@ -45,10 +45,10 @@ const uploadToCloudinary = (buffer: Buffer): Promise<string> => {
   });
 };
 
-const generateShareableLink = (): string => {
+const generateShareableLink = (): { link: string; id: string } => {
   const baseUrl = process.env.FRONTEND_URL || '';
   const uniqueId = crypto.randomBytes(8).toString('hex');
-  return `${baseUrl}/m/${uniqueId}`;
+  return { link: `${baseUrl}/m/${uniqueId}`, id: uniqueId };
 };
 
 const uploadVideoToCloudinaryWithRetry = async (
@@ -259,7 +259,8 @@ export const sendMessage = (req: Request, res: Response) => {
         }
       }
 
-      const shareableLink = generateShareableLink();
+      const onetime = req.body.onetime === 'true' || req.body.onetime === true;
+      const { link: shareableLink, id: linkId } = generateShareableLink();
       const mediaSize = req.file ? req.file.size : null;
 
       const { rows } = await query(
@@ -269,6 +270,13 @@ export const sendMessage = (req: Request, res: Response) => {
       );
 
       const message = rows[0];
+
+      // create entry in message_links table
+      await query(
+        `INSERT INTO message_links (message_id, link_id, passcode, onetime)
+         VALUES ($1, $2, $3, $4)`,
+        [message.id, linkId, passcode || null, onetime]
+      );
 
       if (process.env.NODE_ENV === 'development') {
         console.log(`[Moderation] Message ${message.id} stored with status ${moderationStatus}`);
@@ -300,6 +308,7 @@ export const sendMessage = (req: Request, res: Response) => {
         mediaType: message.mediatype,
         mediaSize: message.media_size,
         shareableLink: message.shareablelink,
+        onetime,
         reactionLength: message.reaction_length,
         maxReactionsAllowed: message.max_reactions_allowed, // Include new field in response
         createdAt: new Date(message.createdat).toISOString(),
@@ -566,9 +575,14 @@ export const updateMessage = async (req: Request, res: Response): Promise<void> 
     queryParams.push(id, user.id);
 
     // Execute update query
-    const { rows: updatedRows, rowCount } = await query(updateQuery, queryParams);
+    const updateRes = await query(updateQuery, queryParams);
+    const updatedRows = updateRes.rows;
 
-    if (rowCount === 0) {
+    if (updatedRows.length > 0 && passcode !== undefined) {
+      await query('UPDATE message_links SET passcode = $1 WHERE message_id = $2', [passcode === null ? null : passcode, id]);
+    }
+
+    if (updatedRows.length === 0) {
       // This could happen if the senderid condition fails despite earlier checks (e.g., race condition or if the message was deleted)
       // Or if the ID itself was not found in this atomic operation.
       res.status(404).json({ error: 'Message not found or update failed due to ownership mismatch.' });
@@ -597,6 +611,96 @@ export const updateMessage = async (req: Request, res: Response): Promise<void> 
     res.status(500).json({ error: 'Failed to update message' });
     return;
   }
+};
+
+export const createMessageLink = async (req: Request, res: Response): Promise<void> => {
+  const { id } = req.params;
+  const onetime = req.body.onetime === 'true' || req.body.onetime === true;
+
+  if (!req.user) {
+    res.status(401).json({ error: 'Authentication required to create links.' });
+    return;
+  }
+
+  const user = req.user as AppUser;
+
+  const { rows: messageRows } = await query('SELECT * FROM messages WHERE id = $1', [id]);
+  if (!messageRows.length) {
+    res.status(404).json({ error: 'Message not found' });
+    return;
+  }
+  const message = messageRows[0];
+  if (message.senderid !== user.id) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+
+  const { link, id: linkId } = generateShareableLink();
+
+  await query(
+    `INSERT INTO message_links (message_id, link_id, passcode, onetime)
+     VALUES ($1, $2, $3, $4)`,
+    [message.id, linkId, message.passcode, onetime]
+  );
+
+  res.status(201).json({ id: linkId, link, onetime });
+};
+
+export const getMessageLinks = async (req: Request, res: Response): Promise<void> => {
+  const { id } = req.params;
+  if (!req.user) {
+    res.status(401).json({ error: 'Authentication required' });
+    return;
+  }
+  const user = req.user as AppUser;
+  const { rows: msgRows } = await query('SELECT senderid FROM messages WHERE id = $1', [id]);
+  if (!msgRows.length) {
+    res.status(404).json({ error: 'Message not found' });
+    return;
+  }
+  if (msgRows[0].senderid !== user.id) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  const { rows } = await query(
+    'SELECT link_id, onetime, viewed, created_at, updated_at FROM message_links WHERE message_id = $1 ORDER BY created_at ASC',
+    [id]
+  );
+  const liveOneTime = rows.filter(r => r.onetime && !r.viewed).length;
+  const expiredOneTime = rows.filter(r => r.onetime && r.viewed).length;
+  res.status(200).json({
+    links: rows.map(r => ({
+      id: r.link_id,
+      onetime: r.onetime,
+      viewed: r.viewed,
+      createdAt: new Date(r.created_at).toISOString(),
+      updatedAt: new Date(r.updated_at).toISOString(),
+    })),
+    stats: { liveOneTime, expiredOneTime }
+  });
+};
+
+export const deleteMessageLink = async (req: Request, res: Response): Promise<void> => {
+  const { linkId } = req.params;
+  if (!req.user) {
+    res.status(401).json({ error: 'Authentication required' });
+    return;
+  }
+  const user = req.user as AppUser;
+  const { rows } = await query(
+    'SELECT ml.message_id, m.senderid FROM message_links ml JOIN messages m ON ml.message_id = m.id WHERE ml.link_id = $1',
+    [linkId]
+  );
+  if (!rows.length) {
+    res.status(404).json({ error: 'Link not found' });
+    return;
+  }
+  if (rows[0].senderid !== user.id) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  await query('DELETE FROM message_links WHERE link_id = $1', [linkId]);
+  res.status(200).json({ success: true });
 };
 
 export const deleteAllReactionsForMessage = async (req: Request, res: Response): Promise<void> => {
@@ -728,22 +832,33 @@ export const deleteReactionById = async (req: Request, res: Response): Promise<v
 export const getMessageByShareableLink = async (req: Request, res: Response): Promise<void> => {
   try {
     const { linkId } = req.params;
-    const shareableLink = `${process.env.FRONTEND_URL}/m/${linkId}`;
-    const { rows } = await query('SELECT * FROM messages WHERE shareablelink = $1', [shareableLink]);
+    const { rows } = await query(
+      `SELECT m.*, ml.onetime, ml.viewed, ml.passcode
+       FROM message_links ml
+       JOIN messages m ON ml.message_id = m.id
+       WHERE ml.link_id = $1`,
+      [linkId]
+    );
 
-    if (!rows.length) {
-      res.status(404).json({ error: 'Message not found' });
-      return;
+    let message = rows[0];
+    if (!message) {
+      const shareableLink = `${process.env.FRONTEND_URL}/m/${linkId}`;
+      const legacy = await query('SELECT * FROM messages WHERE shareablelink = $1', [shareableLink]);
+      if (!legacy.rows.length) {
+        res.status(404).json({ error: 'Message not found' });
+        return;
+      }
+      message = legacy.rows[0];
     }
 
-    const message = rows[0];
     const hasPasscode = !!message.passcode;
 
     if (hasPasscode) {
       res.status(200).json({
         id: message.id,
         hasPasscode: true,
-        reaction_length: message.reaction_length, // Add reaction_length
+        onetime: message.onetime || false,
+        reaction_length: message.reaction_length,
         createdAt: new Date(message.createdat).toISOString()
       });
       return;
@@ -754,7 +869,8 @@ export const getMessageByShareableLink = async (req: Request, res: Response): Pr
       content: message.content,
       imageUrl: message.imageurl,
       hasPasscode: false,
-      reaction_length: message.reaction_length, // Add reaction_length
+      onetime: message.onetime || false,
+      reaction_length: message.reaction_length,
       mediaSize: message.media_size,
       createdAt: new Date(message.createdat).toISOString()
     });
@@ -772,15 +888,24 @@ export const verifyMessagePasscode = async (req: Request, res: Response): Promis
     const { id } = req.params;
     const { passcode } = req.body;
 
-    const shareableLink = `${process.env.FRONTEND_URL}/m/${id}`;
-    const { rows } = await query('SELECT * FROM messages WHERE shareablelink = $1', [shareableLink]);
+    const { rows } = await query(
+      `SELECT m.*, ml.id as link_id, ml.onetime, ml.viewed
+       FROM message_links ml
+       JOIN messages m ON ml.message_id = m.id
+       WHERE ml.link_id = $1`,
+      [id]
+    );
 
-    if (!rows.length) {
-      res.status(404).json({ error: 'Message not found' });
-      return;
+    let message = rows[0];
+    if (!message) {
+      const shareableLink = `${process.env.FRONTEND_URL}/m/${id}`;
+      const legacy = await query('SELECT * FROM messages WHERE shareablelink = $1', [shareableLink]);
+      if (!legacy.rows.length) {
+        res.status(404).json({ error: 'Message not found' });
+        return;
+      }
+      message = legacy.rows[0];
     }
-
-    const message = rows[0];
 
     if (message.passcode !== passcode) {
       res.status(403).json({ error: 'Invalid passcode', verified: false });
@@ -799,6 +924,7 @@ export const verifyMessagePasscode = async (req: Request, res: Response): Promis
         content: message.content,
         imageUrl: message.imageurl,
         hasPasscode: true,
+        onetime: message.onetime || false,
         passcodeVerified: true,
         mediaSize: message.media_size,
         createdAt: new Date(message.createdat).toISOString()
@@ -1104,7 +1230,7 @@ export const deleteMessageAndReaction = async (req: Request, res: Response): Pro
 
 export const initReaction = async (req: Request, res: Response): Promise<void> => {
   const { messageId } = req.params; // This is actual_message_id
-  const { sessionid, name } = req.body;
+  const { sessionid, name, linkId } = req.body;
 
   console.log("[InitReactionLog] Entering function. messageId:", messageId, "sessionid:", sessionid);
 
@@ -1137,6 +1263,23 @@ export const initReaction = async (req: Request, res: Response): Promise<void> =
     // actualMessageId is messageId from params
     const messageSenderId = messageDetails.senderid;
     console.log("[InitReactionLog] Fetched messageDetails:", { id: messageId, senderid: messageSenderId, max_reactions_allowed: messageDetails.max_reactions_allowed });
+
+    // If a linkId was provided, verify it and mark viewed if onetime
+    if (linkId) {
+      const linkRes = await query('SELECT onetime, viewed FROM message_links WHERE link_id = $1 AND message_id = $2', [linkId, messageId]);
+      if (!linkRes.rows.length) {
+        res.status(404).json({ error: 'Link not found' });
+        return;
+      }
+      const link = linkRes.rows[0];
+      if (link.onetime && link.viewed) {
+        res.status(403).json({ error: 'Link expired' });
+        return;
+      }
+      if (link.onetime && !link.viewed) {
+        await query('UPDATE message_links SET viewed = true, updated_at = NOW() WHERE link_id = $1', [linkId]);
+      }
+    }
 
     // 2. Fetch Message Sender's User Details
     const senderQueryText = `

--- a/src/routes/messageRoutes.ts
+++ b/src/routes/messageRoutes.ts
@@ -18,7 +18,10 @@ import {
   deleteReactionById,
   deleteAllReactionsForMessage,
   submitMessageForManualReview,
-  submitReactionForManualReview
+  submitReactionForManualReview,
+  createMessageLink,
+  getMessageLinks,
+  deleteMessageLink
 } from '../controllers/messageController';
 import { requireAuth } from '../middlewares/middleware';
 import multer from 'multer';
@@ -57,6 +60,9 @@ router.get('/messages/:id', getMessageById);
 router.put('/messages/:id', requireAuth, updateMessage); // Added PUT route for updating messages
 router.get('/messages/view/:linkId', getMessageByShareableLink);
 router.post('/messages/:id/verify-passcode', verifyMessagePasscode);
+router.post('/messages/:id/links', requireAuth, createMessageLink);
+router.get('/messages/:id/links', requireAuth, getMessageLinks);
+router.delete('/messages/links/:linkId', requireAuth, deleteMessageLink);
 router.post('/reactions/init/:messageId', initReaction);
 router.put('/reactions/:reactionId/video', upload.single('video'), uploadReactionVideo);
 router.post('/reactions/:id', upload.single('video'), recordReaction);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -106,5 +106,6 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
-  "exclude": ["jest.config.js"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "jest.config.js"]
 }


### PR DESCRIPTION
## Summary
- add migration for `message_links` table
- allow messages to generate one-time links
- update message passcodes across all links when edited
- expose CRUD endpoints for message links
- mark one-time links as viewed when a reaction is initiated

## Testing
- `npm run build`
- `npm test` *(fails: mockQuery.mockClear is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_684d9991c89483249554d3f488e91be1