### PR TITLE
Store auth token in http-only cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is the backend service for the Reactlyve application, providing API endpoin
     *   Google OAuth 2.0 for user sign-up and login.
     *   JWT (JSON Web Tokens) for securing API access.
     *   Tokens are set in an HTTP-only `token` cookie to mitigate XSS risks.
+    *   OAuth login uses a short-lived `state` cookie to prevent CSRF attacks.
 *   **User Management:**
     *   User roles: `user`, `admin`, `guest`.
     *   Users can view their profile and delete their own account.
@@ -143,6 +144,7 @@ The API provides several route groups for different functionalities:
 
 *   **`/api/auth`**: Handles user authentication.
     *   Google login initiation and callback.
+    *   OAuth requests include a `state` value stored in an `oauth_state` cookie and validated on callback.
     *   Fetching current authenticated user details.
     *   Logging out via `POST /api/auth/logout` (clears the auth cookie).
    *   **`/api/messages`** (and related routes for reactions/replies): Manages the messaging system.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is the backend service for the Reactlyve application, providing API endpoin
 *   **Authentication:**
     *   Google OAuth 2.0 for user sign-up and login.
     *   JWT (JSON Web Tokens) for securing API access.
+    *   Tokens are set in an HTTP-only `token` cookie to mitigate XSS risks.
 *   **User Management:**
     *   User roles: `user`, `admin`, `guest`.
     *   Users can view their profile and delete their own account.
@@ -143,6 +144,7 @@ The API provides several route groups for different functionalities:
 *   **`/api/auth`**: Handles user authentication.
     *   Google login initiation and callback.
     *   Fetching current authenticated user details.
+    *   Logging out via `POST /api/auth/logout` (clears the auth cookie).
    *   **`/api/messages`** (and related routes for reactions/replies): Manages the messaging system.
       *   Creating, retrieving, updating, and deleting messages.
       *   Verifying passcodes for protected links.

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@types/express": "^5.0.3",
         "@types/jest": "^30.0.0",
         "@types/multer": "^1.4.13",
+        "@types/node": "^24.0.3",
         "@types/pg": "^8.15.4",
         "jest": "^30.0.0",
         "ts-jest": "^29.4.0",
@@ -1481,11 +1482,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.15.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.12.tgz",
-      "integrity": "sha512-K0fpC/ZVeb8G9rm7bH7vI0KAec4XHEhBam616nVJCV51bKzJ6oA3luG4WdKoaztxe70QaNjS/xBmcDLmr4PiGw==",
+      "version": "24.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
+      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/oauth": {
@@ -6342,9 +6344,10 @@
       "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA=="
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "uuid": "^11.1.0"
       },
       "devDependencies": {
+        "@types/cookie-parser": "^1.4.9",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/jest": "^30.0.0",
@@ -1365,6 +1366,16 @@
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.9.tgz",
+      "integrity": "sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/cors": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/passport-google-oauth20": "^2.0.16",
         "bcrypt": "^6.0.0",
         "cloudinary": "^2.6.1",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
@@ -2533,6 +2534,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/passport-google-oauth20": "^2.0.16",
     "bcrypt": "^6.0.0",
     "cloudinary": "^2.6.1",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "uuid": "^11.1.0"
   },
   "devDependencies": {
+    "@types/cookie-parser": "^1.4.9",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",
     "@types/multer": "^1.4.13",
+    "@types/node": "^24.0.3",
     "@types/pg": "^8.15.4",
     "jest": "^30.0.0",
     "ts-jest": "^29.4.0",

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -18,8 +18,16 @@ export const generateToken = (user: AppUser):string => { // Changed User to AppU
 export const googleCallback = (req: Request, res: Response) => {
   const user = req.user as AppUser; // Changed User to AppUser
   const token = generateToken(user);
-  // Redirect back to frontend with token
-  const redirectUrl = `${process.env.FRONTEND_URL}/auth/success?token=${token}`;
+  const cookieOptions: any = {
+    httpOnly: true,
+    sameSite: 'lax',
+    maxAge: 7 * 864e5,
+  };
+  if (process.env.NODE_ENV === 'production') {
+    cookieOptions.secure = true;
+  }
+  res.cookie('token', token, cookieOptions);
+  const redirectUrl = `${process.env.FRONTEND_URL}/auth/success`;
   res.redirect(redirectUrl);
   return; // Adjusted for void compatibility
 };

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -32,6 +32,18 @@ export const googleCallback = (req: Request, res: Response) => {
   return; // Adjusted for void compatibility
 };
 
+export const logout = (req: Request, res: Response) => {
+  const cookieOptions: any = {
+    httpOnly: true,
+    sameSite: 'lax',
+  };
+  if (process.env.NODE_ENV === 'production') {
+    cookieOptions.secure = true;
+  }
+  res.clearCookie('token', cookieOptions);
+  res.status(200).json({ message: 'Logged out successfully' });
+};
+
 export const getCurrentUser = (req: Request, res: Response) => {
   try {
     // requireAuth middleware should ensure req.user is populated.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import "dotenv/config";
 import express, { NextFunction, Request, Response } from "express";
 import cors from "cors";
+import cookieParser from "cookie-parser";
 import { Pool } from 'pg';
 import { dbConfig } from './config/database.config';
 import passport from './config/passport';
@@ -25,6 +26,7 @@ const app = express();
 app.set('trust proxy', 2);
 
 app.use(express.json());
+app.use(cookieParser());
 
 app.use(express.urlencoded({ extended: true }));
 

--- a/src/middlewares/middleware.ts
+++ b/src/middlewares/middleware.ts
@@ -7,11 +7,16 @@ import { query } from '../config/database.config';
 // Global Express Request augmentation removed, will be handled by src/types/express.d.ts
 
 export const requireAuth = async (req: Request, res: Response, next: NextFunction):Promise<any> => {
+  let token: string | undefined;
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith('Bearer ')) {
+  if (authHeader?.startsWith('Bearer ')) {
+    token = authHeader.split(' ')[1];
+  } else if (req.cookies && req.cookies.token) {
+    token = req.cookies.token;
+  }
+  if (!token) {
     return res.status(401).json({ error: 'Authentication required' });
   }
-  const token = authHeader.split(' ')[1];
   try {
     const payload = jwt.verify(token, process.env.JWT_SECRET!) as { id: string };
     // Optionally fetch full user

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -22,7 +22,7 @@
 
 import { Router } from 'express';
 import passport from 'passport';
-import { googleCallback, getCurrentUser } from '../controllers/authController';
+import { googleCallback, getCurrentUser, logout } from '../controllers/authController';
 import { requireAuth } from '../middlewares/middleware';
 
 const router = Router();
@@ -41,5 +41,7 @@ router.get(
 );
 //@ts-ignore
 router.get('/me', requireAuth, getCurrentUser);
+
+router.post('/logout', logout);
 
 export default router;

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -23,16 +23,21 @@
 import { Router } from 'express';
 import passport from 'passport';
 import { googleCallback, getCurrentUser, logout } from '../controllers/authController';
-import { requireAuth } from '../middlewares/middleware';
+import { requireAuth, setOAuthStateCookie, verifyOAuthState } from '../middlewares/middleware';
 
 const router = Router();
 
-router.get('/google', passport.authenticate('google', {
-  scope: ['profile', 'email']
-}));
+router.get('/google', setOAuthStateCookie, (req: any, res, next) => {
+  const state = req.oauthState as string;
+  passport.authenticate('google', {
+    scope: ['profile', 'email'],
+    state,
+  })(req, res, next);
+});
 
 router.get(
   '/google/callback',
+  verifyOAuthState,
   passport.authenticate('google', {
     session: false,
     failureRedirect: `${process.env.FRONTEND_URL}/login`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
     "rootDir": "./src",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node",                          /* Resolve modules using Node.js strategy. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
@@ -107,5 +107,5 @@
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "jest.config.js"]
+  "exclude": ["node_modules", "dist", "jest.config.js", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- install `cookie-parser`
- set cookie parser middleware
- set auth token cookie in OAuth callback
- read token from cookie in auth middleware

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685318f5c1b483249003f5d054ec1a05