### PR TITLE
Add CSP frame-ancestors header

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Create a `.env` file in the root directory of the project and populate it with t
 PORT=3000
 NODE_ENV=development # or 'production'
 FRONTEND_URL=http://localhost:3001 # URL of your frontend application for CORS and redirects
+CSP_FRAME_ANCESTORS='none' # Allowed origins for framing. Use 'none' to disallow
 
 # Administrative Accounts
 ADMIN_EMAILS=admin1@example.com,admin2@example.com # Comma-separated list

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,13 @@ app.use(
   })
 );
 
+// Set Content Security Policy to control framing
+app.use((_, res, next) => {
+  const frameAncestors = process.env.CSP_FRAME_ANCESTORS || "'none'";
+  res.setHeader('Content-Security-Policy', `frame-ancestors ${frameAncestors}`);
+  next();
+});
+
 app.use(passport.initialize());
 
 app.use((req, res, next) => {


### PR DESCRIPTION
## Summary
- send `Content-Security-Policy` header that sets frame-ancestors
- document new `CSP_FRAME_ANCESTORS` env variable

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685472a45b9c8324a9bd7a5d1572bb3b