### PR TITLE
Remove audio reply support

### DIFF
--- a/src/controllers/messageController.ts
+++ b/src/controllers/messageController.ts
@@ -1225,10 +1225,7 @@ export const recordMediaReply = async (req: Request, res: Response): Promise<voi
     }
     const messageId = reactionRes.rows[0].messageid;
 
-    const mediatype = req.file.mimetype.startsWith('audio/') ? 'audio' : 'video';
-    // Cloudinary stores audio under the `video` resource type, so even audio
-    // files are uploaded with the video API. We keep the user's intended media
-    // type in the DB via `mediatype` for clarity.
+    const mediatype = 'video';
 
     const senderPrefRes = await query('SELECT moderate_videos FROM messages m JOIN users u ON m.senderid = u.id WHERE m.id = $1', [messageId]);
     const moderateVideos = senderPrefRes.rows.length ? senderPrefRes.rows[0].moderate_videos === true : false;
@@ -1237,11 +1234,11 @@ export const recordMediaReply = async (req: Request, res: Response): Promise<voi
       req.file.buffer,
       req.file.size,
       'reply_media',
-      mediatype === 'video' && moderateVideos ? { moderation: 'aws_rek_video' } : {}
+      moderateVideos ? { moderation: 'aws_rek_video' } : {}
     );
 
     const mediaUrl = uploadResult.secure_url;
-    const thumbnailUrl = mediatype === 'video' ? uploadResult.thumbnail_url : null;
+    const thumbnailUrl = uploadResult.thumbnail_url;
     const duration = uploadResult.duration !== null && uploadResult.duration !== undefined
       ? Math.round(uploadResult.duration)
       : 0;

--- a/src/routes/messageRoutes.ts
+++ b/src/routes/messageRoutes.ts
@@ -51,15 +51,15 @@ const upload = multer({
   }
 });
 
-// Multer setup for reply media (video or audio)
+// Multer setup for reply media (video only)
 const replyUpload = multer({
   storage: multer.memoryStorage(),
   limits: { fileSize: 50 * 1024 * 1024 },
   fileFilter: (req, file, cb) => {
-    if (file.mimetype.startsWith('video/') || file.mimetype.startsWith('audio/')) {
+    if (file.mimetype.startsWith('video/')) {
       cb(null, true);
     } else {
-      cb(new Error('Only video or audio files are allowed!') as any, false);
+      cb(new Error('Only video files are allowed!') as any, false);
     }
   }
 });


### PR DESCRIPTION
## Summary
- disallow audio uploads for replies and update comment
- simplify `recordMediaReply` now that only videos are allowed

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686128d9c8848324b71bc213d938c166